### PR TITLE
Machine type metadata

### DIFF
--- a/X3GWriter.py
+++ b/X3GWriter.py
@@ -7,6 +7,7 @@ import os
 from UM.Mesh.MeshWriter import MeshWriter
 from UM.Logger import Logger
 from UM.PluginRegistry import PluginRegistry #To get the g-code from the GCodeWriter plug-in.
+from UM.Application import Application
 import UM.Platform
 
 class X3GWriter(MeshWriter):

--- a/X3GWriter.py
+++ b/X3GWriter.py
@@ -21,6 +21,9 @@ class X3GWriter(MeshWriter):
     #   \param mode The output mode to use. This is ignored, since it has no
     #   meaning.
     def write(self, stream, nodes, mode = MeshWriter.OutputMode.TextMode):
+        if mode != MeshWriter.OutputMode.TextMode:
+            Logger.log("e", "X3G Writer does not support non-text mode.")
+            return False
         #Find an unused file name to temporarily write the g-code to.
         file_name = stream.name
         if not file_name: #Not a file stream.


### PR DESCRIPTION
The main contents of this pull request is to allow machine type definitions to specify the x3g machine variant that they need. This means that my Replicator 2X machine defs can now automatically tell this plugin to make the right kind of x3g file.

(It also auto-detects when the `-g` parameter, for "MakerBot-style G-code", is required)