### PR TITLE
Machine setting fixes

### DIFF
--- a/X3GWriter.py
+++ b/X3GWriter.py
@@ -180,7 +180,7 @@ class X3GWriter(MeshWriter):
         parser["machine"]["packing_density"] = "1.0" #Seems to be the same as the printer category.
         parser["machine"]["nozzle_diameter"] = str(extruder_stacks[0].getProperty("machine_nozzle_size", "value")) #The diameter of the nozzle seems to be quintessentially per-extruder, but GPX doesn't allow setting it per extruder. Just take one of them.
         parser["machine"]["extruder_count"] = str(global_stack.getProperty("machine_extruder_count", "value"))
-        parser["machine"]["timeout"] = "10" #Let's just always home at most 10 seconds. No need to make that configurable per printer (yet).
+        parser["machine"]["timeout"] = "20" #Let's just always home at most 20 seconds. This is what GPX uses for all built-in printers.
         #parser["machine"]["steps_per_mm"] = ? #I think the steps_per_mm per axis will override this.
 
         parser.write(cfg_stream)

--- a/X3GWriter.py
+++ b/X3GWriter.py
@@ -123,7 +123,7 @@ class X3GWriter(MeshWriter):
 
         parser.add_section("printer") #Slicer data.
         parser["printer"]["ditto_printing"] = "0" #Whether to duplicate the extrusion with all extruders. Cura doesn't support this.
-        parser["printer"]["build_progress"] = "0" #TODO: I don't know what data GPX needs to be able to 'build progress'.
+        parser["printer"]["build_progress"] = "1" #Let GPX calculate the percent done counter shown on the printer's display.
         parser["printer"]["packing_density"] = "1.0" #TODO: 1.0 is the default but I don't know what this means. It's not documented.
         parser["printer"]["recalculate_5d"] = "1" #Whether to re-compute the extrusion widths. Please do! We assume that GPX knows better what to do with the feedrate than Cura.
         parser["printer"]["nominal_filament_diameter"] = str(extruder_stacks[0].getProperty("material_diameter", "value")) #Use the first extruder since it was used for actual slicing, not just matching materials.

--- a/X3GWriter.py
+++ b/X3GWriter.py
@@ -178,7 +178,7 @@ class X3GWriter(MeshWriter):
         parser.add_section("machine")
         parser["machine"]["nominal_filament_diameter"] = str(extruder_stacks[0].getProperty("material_diameter", "value")) #Seems to be the same as the printer category.
         parser["machine"]["packing_density"] = "1.0" #Seems to be the same as the printer category.
-        parser["machine"]["nozzle_diameter"] = str(extruder_stacks[0].getProperty("machine_nozzle_diameter", "value")) #The diameter of the nozzle seems to be quintessentially per-extruder, but GPX doesn't allow setting it per extruder. Just take one of them.
+        parser["machine"]["nozzle_diameter"] = str(extruder_stacks[0].getProperty("machine_nozzle_size", "value")) #The diameter of the nozzle seems to be quintessentially per-extruder, but GPX doesn't allow setting it per extruder. Just take one of them.
         parser["machine"]["extruder_count"] = str(global_stack.getProperty("machine_extruder_count", "value"))
         parser["machine"]["timeout"] = "10" #Let's just always home at most 10 seconds. No need to make that configurable per printer (yet).
         #parser["machine"]["steps_per_mm"] = ? #I think the steps_per_mm per axis will override this.

--- a/X3GWriter.py
+++ b/X3GWriter.py
@@ -152,7 +152,7 @@ class X3GWriter(MeshWriter):
         parser["a"]["max_feedrate"] = str(extruder_stacks[0].getProperty("machine_max_feedrate_e", "value") * 60) #Not configurable per extruder in Cura...
         parser["a"]["steps_per_mm"] = str(extruder_stacks[0].getProperty("machine_steps_per_mm_e", "value")) #How many steps of the stepper motor results in 1mm of filament movement.
         parser["a"]["motor_steps"] = str(extruder_stacks[0].getProperty("machine_feeder_wheel_diameter", "value") * math.pi * extruder_stacks[0].getProperty("machine_steps_per_mm_e", "value")) #Steps to make a full revolution of the feeder wheel.
-        parser["a"]["has_heated_build_platform"] = str(extruder_stacks[0].getProperty("machine_heated_bed", "value")) #Not configurable per extruder in Cura...
+        parser["a"]["has_heated_build_platform"] = str(int(extruder_stacks[0].getProperty("machine_heated_bed", "value"))) #Not configurable per extruder in Cura...
 
         parser.add_section("right") #Right extruder (in the g-code labelled as T0).
         parser["right"]["active_temperature"] = str(extruder_stacks[0].getProperty("material_print_temperature", "value"))
@@ -166,7 +166,7 @@ class X3GWriter(MeshWriter):
             parser["b"]["max_feedrate"] = str(extruder_stacks[1].getProperty("machine_max_feedrate_e", "value") * 60)
             parser["b"]["steps_per_mm"] = str(extruder_stacks[1].getProperty("machine_steps_per_mm_e", "value"))
             parser["b"]["motor_steps"] = str(extruder_stacks[1].getProperty("machine_feeder_wheel_diameter", "value") * math.pi * extruder_stacks[1].getProperty("machine_steps_per_mm_e", "value"))
-            parser["b"]["has_heated_build_platform"] = str(extruder_stacks[1].getProperty("machine_heated_bed", "value"))
+            parser["b"]["has_heated_build_platform"] = str(int(extruder_stacks[1].getProperty("machine_heated_bed", "value")))
 
             parser.add_section("left") #Left extruder (in the g-code labelled as T1).
             parser["left"]["active_temperature"] = str(extruder_stacks[1].getProperty("material_print_temperature", "value"))


### PR DESCRIPTION
This resolves a few remaining issues with the generated GPX configuration.

I've verified this to work acceptably on a ZYYX Agile (together with an updated printer definition to add some missing values used by the generator).